### PR TITLE
Move minimum free space to configuration file - default to 500MB

### DIFF
--- a/archive_and_clean.sh
+++ b/archive_and_clean.sh
@@ -7,11 +7,11 @@ source <( grep = ${BASEDIR}/settings.conf )
 cd ${datadir}
 
 check_space(){
-  df -kP ${datadir} | grep -v '^Filesystem' | awk '{ print $4 }'
+  df -mP ${datadir} | grep -v '^Filesystem' | awk '{ print $4 }'
 }
 
 #Check if there is enough available space (more than 500MB), and delete oldest archive if needed.
-while [[ $(check_space) -lt 500000 ]]
+while [[ $(check_space) -lt ${min_free_space} ]]
 do
   file_to_delete=$(find . -maxdepth 1 -type f | sort -r | tail -1)
   #Test if there is a file to delete

--- a/settings.conf.default
+++ b/settings.conf.default
@@ -55,6 +55,8 @@ file_overlap_time='30'
 archive_name=$(date -d "-1 days" +"%Y-%m-%d_%S").zip
 #archives older than this value (in days) will be deleted by archive_and_clean.sh
 archive_rotate='60'
+#minum free space on device (in MB) before oldest archives are deleted
+min_free_space='500'
 
 [ntrip]
 


### PR DESCRIPTION
Addresses bug and recommendation in #140. 

Corrects default cleanup size to 500MB of free space.
