### PR TITLE
Change hardcoded port of server.py from 80 to 8008

### DIFF
--- a/web_app/server.py
+++ b/web_app/server.py
@@ -768,7 +768,7 @@ if __name__ == "__main__":
         manager_thread.start()
 
         app.secret_key = rtkbaseconfig.get_secret_key()
-        socketio.run(app, host = "0.0.0.0", port = 80)
+        socketio.run(app, host = "0.0.0.0", port = 8008)
 
     except KeyboardInterrupt:
         print("Server interrupted by user!!")


### PR DESCRIPTION
Change hardcoded port of server.py from 80 to 8008 to not interfere with existing web server application using port 80.
Ideally, port number should be made configurable and store in settings.conf.default...