### PR TITLE
Socket messaging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,4 @@
 # Changelog
-
-## [2.3.5] - not released
-### Added
-### Changed
-- Flask upgraded to v2.0.3 and other dependencies upgraded too.
-### Fixed
-- GUI -> Status: Sat. levels and coordinates are set to zero in case of a signal interruption. #164
-
-### Security
-
 ## [2.3.4] - 2022-04-01
 ### Fixed 
  - Failure with some python dependancies. #215
@@ -30,6 +20,7 @@
 - GUI -> Status: Ortho HR (aerial images) max zoom changed from 20 to 21.
 ### Fixed
 - GUI -> Settings: "Save" buttons are disabled when a new setting is saved. #193
+- Rtcm and Ntrip services are restarded after a RTKBase update. #171
 - The Rinex conversion is more robust and error message is more understandable.
 - GUI -> Rinex conversion is now enabled only for zip files.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Frontend's main features are:
 Other images are available in the ./images folder.
 
 ## Ready to flash release:
-A ready to flash image is available for Orange Pi Zero SBC : [Armbian_22.02 bullseye current 5.15.24](https://rtkbase.eu/armbian_rtkbase/Armbian_22.02.0-trunk_Orangepizero_bullseye_current_5.15.24_minimal.zip)
+A ready to flash image is available for Orange Pi Zero SBC : [Armbian_RTKBase](https://github.com/Stefal/build/releases/latest)
 
-If you use a Raspberry Pi, thanks to [jancelin](https://github.com/jancelin), you can download a ready to flash iso file [here](https://github.com/jancelin/pi-gen/releases).
+If you use a Raspberry Pi, thanks to [jancelin](https://github.com/jancelin), you can download a ready to flash iso file [here](https://github.com/jancelin/pi-gen/releases/latest).
 
 ## Easy installation:
 + Connect your gnss receiver to your raspberry pi/orange pi/....

--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -156,23 +156,18 @@ upd_2.3.2() {
 }
 
 upd_2.3.3() {
- #update gpsd unit file
- cp /lib/systemd/system/gpsd.service /etc/systemd/system/gpsd.service
- sed -i 's/^After=.*/After=str2str_tcp.service/' /etc/systemd/system/gpsd.service
- sed -i '/^# Needed with chrony/d' /etc/systemd/system/gpsd.service
- #Add restart condition
- grep -qi '^Restart=' /etc/systemd/system/gpsd.service || sed -i '/^ExecStart=.*/a Restart=always' /etc/systemd/system/gpsd.service
- grep -qi '^RestartSec=' /etc/systemd/system/gpsd.service || sed -i '/^Restart=always.*/a RestartSec=30' /etc/systemd/system/gpsd.service
- #Add ExecStartPre condition to not start gpsd if str2str_tcp is not running. See https://github.com/systemd/systemd/issues/1312
- grep -qi '^ExecStartPre=' /etc/systemd/system/gpsd.service || sed -i '/^ExecStart=.*/i ExecStartPre=systemctl is-active str2str_tcp.service' /etc/systemd/system/gpsd.service
- systemctl daemon-reload
- systemctl restart gpsd  
- upd_2.3.4 "$@"
-}
+#Overriding gpsd.service with custom dependency
+cp /lib/systemd/system/gpsd.service /etc/systemd/system/gpsd.service
+sed -i 's/^After=.*/After=str2str_tcp.service/' /etc/systemd/system/gpsd.service
+sed -i '/^# Needed with chrony/d' /etc/systemd/system/gpsd.service
+#Add restart condition
+grep -qi '^Restart=' /etc/systemd/system/gpsd.service || sed -i '/^ExecStart=.*/a Restart=always' /etc/systemd/system/gpsd.service
+grep -qi '^RestartSec=' /etc/systemd/system/gpsd.service || sed -i '/^Restart=always.*/a RestartSec=30' /etc/systemd/system/gpsd.service
+#Add ExecStartPre condition to not start gpsd if str2str_tcp is not running. See https://github.com/systemd/systemd/issues/1312
+grep -qi '^ExecStartPre=' /etc/systemd/system/gpsd.service || sed -i '/^ExecStart=.*/i ExecStartPre=systemctl is-active str2str_tcp.service' /etc/systemd/system/gpsd.service
 
-upd_2.3.4() {
-#update python module
-    python3 -m pip install -r ${destination_directory}'/web_app/requirements.txt' --extra-index-url https://www.piwheels.org/simple
+systemctl daemon-reload
+systemctl restart gpsd
 }
 
 # standard update
@@ -180,18 +175,25 @@ update
 # calling specific update function. If we are using v2.2.5, it will call the function upd_2.2.5
 upd_${old_version} "$@"
 
-# The new version numbers will be imported from settings.conf.default during the web server startup.
-echo "Delete the line version= and checkpoint_version= in settings.conf"
-sed -i '/^checkpoint_version=/d' ${destination_directory}/settings.conf
-sed -i '/^version=/d' ${destination_directory}/settings.conf
-echo 'Insert updated status in settings.conf'
-sed -i '/^\[general\]/a updated=true' ${destination_directory}/settings.conf
+# The new checkpoint_version number will be imported from settings.conf.default during the web server startup.
+echo "delete the line checkpoint_version= in settings.conf"
+sed -i '/checkpoint_version=/d' ${destination_directory}/settings.conf
+
+echo "update the release version in settings.conf"
+new_release=$(grep '^version=*' ${destination_directory}/settings.conf.default)
+sed -i 's/^version=.*/'${new_release}'/' ${destination_directory}/settings.conf
 
 #change rtkbase's content owner
 chown -R ${standard_user}:${standard_user} ${destination_directory}
 
-#if a reboot is needed
-#systemctl reboot
+echo 'restart ntrip/rtcm to send the new release number in the stream'
+systemctl is-active --quiet str2str_ntrip.service && systemctl restart str2str_ntrip.service
+systemctl is-active --quiet str2str_local_ntrip_caster.service && systemctl restart str2str_local_ntrip_caster.service
+systemctl is-active --quiet str2str_rtcm_svr.service && systemctl restart str2str_rtcm_svr.service
+systemctl is-active --quiet str2str_rtcm_serial.service && systemctl restart str2str_rtcm_serial.service
 
 echo "Restart web server"
 systemctl restart rtkbase_web.service
+
+#if a reboot is needed
+#systemctl reboot

--- a/tools/convbin.sh
+++ b/tools/convbin.sh
@@ -66,5 +66,5 @@ RINEX=$(echo "${filedate}"-"${MOUNT_NAME}"."${year2}"o)
 echo "- Processing on	""${RAW_ARCHIVE}"
 extract_raw_file                  && \
 ${rnx_conversion_func}            && \
-echo -n 'rinex_file='"${RINEX}"
+echo -n 'rinex_file='"${RINEX}"   && \
 rm "${raw_file}"

--- a/web_app/RTKBaseConfigManager.py
+++ b/web_app/RTKBaseConfigManager.py
@@ -169,12 +169,6 @@ class RTKBaseConfigManager:
         """
         return self.config.get(*args, **kwargs)
 
-    def remove_option(self, *args, **kwargs):
-        """
-            a wrapper around configparser.remove_options()
-        """
-        return self.config.remove_option(*args, **kwargs)
-    
     def update_setting(self, section, setting, value, write_file=True):
         """
             Update a setting in the config file and write the file (default)

--- a/web_app/RTKLIB.py
+++ b/web_app/RTKLIB.py
@@ -698,17 +698,11 @@ class RTKLIB:
     # and emits them to the connected browser as messages
     def broadcastSatellites(self):
         count = 0
-        last_gps_timestamp=""
 
         while self.server_not_interrupted:
 
             # update satellite levels
             self.rtkc.getObs()
-            #check if gps time is the same (no signal input)
-            if last_gps_timestamp == self.rtkc.obs_rover.get("gps_time"):
-                self.rtkc.obs_rover = {}
-            else:
-                last_gps_timestamp = self.rtkc.obs_rover.get("gps_time")
 
 #            if count % 10 == 0:
             #print("Sending sat rover levels:\n" + str(self.rtkc.obs_rover))
@@ -724,17 +718,11 @@ class RTKLIB:
     # this function reads current rtklib status, coordinates and obs count
     def broadcastCoordinates(self):
         count = 0
-        last_receiver_timestamp = ""
+
         while self.server_not_interrupted:
 
             # update RTKLIB status
             self.rtkc.getStatus()
-
-            #check if receiver time is the same (no signal input)
-            if last_receiver_timestamp == self.rtkc.status.get("time of receiver clock rover"):
-                self.rtkc.status = {}
-            else:
-                last_receiver_timestamp = self.rtkc.status.get("time of receiver clock rover")
 
 #            if count % 10 == 0:
 #                print("Sending RTKLIB status select information:")

--- a/web_app/RtkController.py
+++ b/web_app/RtkController.py
@@ -267,6 +267,7 @@ class RtkController:
 
         obs = self.child.before.decode().split("\r\n")
         obs = [_f for _f in obs if _f]
+
         matching_strings = [s for s in obs if "SAT" in s]
 
         if matching_strings != []:
@@ -281,7 +282,6 @@ class RtkController:
                 sat_name_index = header.index("SAT")
                 sat_level_index = header.index("S1")
                 sat_input_source_index = header.index("R")
-                sat_time_index = header.index("TIME(GPST)")
 
                 if len(obs) > (header_index + 1):
                     # we have some info about the actual satellites:
@@ -295,22 +295,19 @@ class RtkController:
                         if len(spl) > sat_level_index:
                             name = spl[sat_name_index]
                             level = spl[sat_level_index]
-                            gps_time = spl[sat_time_index]
 
                             # R parameter corresponds to the input source number
                             if spl[sat_input_source_index] == "1":
                                 # we consider 1 to be rover,
                                 self.obs_rover[name] = level
-                                self.obs_rover["gps_time"] = gps_time
                             elif spl[sat_input_source_index] == "2":
                                 # 2 to be base
                                 self.obs_base[name] = level
-                                self.obs_base["gps_time"] = gps_time
 
                 else:
                     self.obs_base = {}
                     self.obs_rover = {}
-                    
+
         self.semaphore.release()
 
         return 1

--- a/web_app/requirements.txt
+++ b/web_app/requirements.txt
@@ -1,10 +1,12 @@
-cryptography==36.0.1
-itsdangerous==2.0.1
-Flask==2.0.3
-Flask-SocketIO==5.1.1
-eventlet==0.33.0
-Bootstrap-Flask==2.0.1
-Flask-WTF==1.0.0
+jinja2==3.0.3
+werkzeug==2.0.2
+cryptography==3.3.2
+itsdangerous==1.1.0
+Flask==1.1.2
+Flask-SocketIO==4.3.2
+eventlet==0.31.0
+Bootstrap-Flask==1.5.1
+Flask-WTF==0.14.3
 Flask-Login==0.5.0
 #On some linux distribution, pexpect and psutil are already installed
 #and can't be upgraded with pip. In these cases, pip fail, leaving
@@ -12,8 +14,8 @@ Flask-Login==0.5.0
 #With pexpect <=4.8.0, pip will not fail.
 #With psutil <= 5.8.0, pip will not fail.
 pexpect<=4.8.0
-psutil<=5.9.0
-pyOpenSSL==22.0.0
+psutil<=5.8.0
+pyOpenSSL==20.0.1
 pyserial==3.5
-pystemd==0.10.0
-requests==2.27.1
+pystemd==0.8.0
+requests==2.25.1

--- a/web_app/server.py
+++ b/web_app/server.py
@@ -765,12 +765,6 @@ if __name__ == "__main__":
         services_list = load_units(services_list)
         #Update standard user in settings.conf
         update_std_user(services_list)
-        #check if we run RTKBase for the first time after an update
-        #and restart some services to let them send the new release number.
-        if rtkbaseconfig.get("general", "updated", fallback="False").lower() == "true":
-            restartServices(["ntrip", "local_ntrip_caster", "rtcm_svr", "rtcm_serial"])
-            rtkbaseconfig.remove_option("general", "updated")
-            rtkbaseconfig.write_file()
         #Start a "manager" thread
         manager_thread = Thread(target=manager, daemon=True)
         manager_thread.start()

--- a/web_app/server.py
+++ b/web_app/server.py
@@ -141,32 +141,34 @@ def manager():
         And it sends various system informations to the web interface
     """
     max_cpu_temp = 0
-    services_status = getServicesStatus()
+    services_status = getServicesStatus(emit_pingback=False)
     while True:
         if connected_clients > 0:
-            updated_services_status = getServicesStatus(emit_pingback=True)
+            # We only need to emit to the socket if there are clients able to receive it.
+            updated_services_status = getServicesStatus(emit_pingback=False)
             if  services_status != updated_services_status:
-                services_status = repaint_services_button(updated_services_status)
+                services_status = updated_services_status
                 socketio.emit("services status", json.dumps(services_status), namespace="/test")
                 print("service status", services_status)
 
+            cpu_temp = get_cpu_temp()
+            max_cpu_temp = max(cpu_temp, max_cpu_temp)
+            volume_usage = get_volume_usage()
+            sys_infos = {"cpu_temp" : cpu_temp,
+                        "max_cpu_temp" : max_cpu_temp,
+                        "uptime" : get_uptime(),
+                        "volume_free" : round(volume_usage.free / 10E8, 2),
+                        "volume_used" : round(volume_usage.used / 10E8, 2),
+                        "volume_total" : round(volume_usage.total / 10E8, 2),
+                        "volume_percent_used" : volume_usage.percent}
+            socketio.emit("sys_informations", json.dumps(sys_infos), namespace="/test")
+        
         if rtk.sleep_count > rtkcv_standby_delay and rtk.state != "inactive":
             print("Trying to stop rtkrcv")
             if rtk.stopBase() == 1:
                 rtk.sleep_count = 0
         elif rtk.sleep_count > rtkcv_standby_delay:
             print("I'd like to stop rtkrcv (sleep_count = {}), but rtk.state is: {}".format(rtk.sleep_count, rtk.state))
-        cpu_temp = get_cpu_temp()
-        max_cpu_temp = max(cpu_temp, max_cpu_temp)
-        volume_usage = get_volume_usage()
-        sys_infos = {"cpu_temp" : cpu_temp,
-                    "max_cpu_temp" : max_cpu_temp,
-                    "uptime" : get_uptime(),
-                    "volume_free" : round(volume_usage.free / 10E8, 2),
-                    "volume_used" : round(volume_usage.used / 10E8, 2),
-                    "volume_total" : round(volume_usage.total / 10E8, 2),
-                    "volume_percent_used" : volume_usage.percent}
-        socketio.emit("sys_informations", json.dumps(sys_infos), namespace="/test")
         time.sleep(1)
 
 def repaint_services_button(services_list):
@@ -650,10 +652,14 @@ def restartServices(restart_services_list):
     getServicesStatus()
 
 @socketio.on("get services status", namespace="/test")
-def getServicesStatus(emit_pingback=False):
+def getServicesStatus(emit_pingback=True):
     """
         Get the status of services listed in services_list
         (services_list is global)
+        
+        :param emit_pingback: whether or not the services status is sent to clients 
+            (defaults to true as the socketio.on() should receive back the information)
+        :return The gathered services status list
     """
 
     #print("Getting services status")

--- a/web_app/static/graph.js
+++ b/web_app/static/graph.js
@@ -184,10 +184,7 @@ function Chart() {
         var new_sat_values = [];
 
         for (var k in msg) {
-            // filtering in case of non sat level info in msg (ie gps_time)
-            if (k.length < 4) {
             new_sat_values.push({sat:k, level:msg[k]});
-            }
         }
 
         // sort the sat levels by ascension
@@ -379,9 +376,8 @@ function updateCoordinateGrid(msg) {
         var lat_value = coordinates[0].substring(0, 11) + Array(11 - coordinates[0].substring(0, 11).length + 1).join(" ");
         var lon_value = coordinates[1].substring(0, 11) + Array(11 - coordinates[1].substring(0, 11).length + 1).join(" ");
         var height_value = coordinates[2].substring(0, 11) + Array(11 - coordinates[2].substring(0, 11).length + 1 + 2).join(" ");
-        var solution_status = 'solution status' in msg ? msg['solution status'] : '-';
         $("#lat_value").html(lat_value + " °");
         $("#lon_value").html(lon_value + " °");
         $("#height_value").html(height_value + "m");
-        $("#solution_status").html(solution_status);
+        $("#solution_status").html(msg['solution status']);
 }


### PR DESCRIPTION
Small QOL improvement.

- Only sent system informations when there is a client connected.
- Makes UI more responsive by defaulting `emit_pingback` to `True`, so that the services status get sent back to the client immediate instead of waiting on the manager function:
  ```diff
    @socketio.on("get services status", namespace="/test")
  - def getServicesStatus(emit_pingback=False):
  + def getServicesStatus(emit_pingback=True):
        """
            Get the status of services listed in services_list
            (services_list is global)
          
  +        :param emit_pingback: whether or not the services status is sent to clients 
  +            (defaults to true as the socketio.on() should receive back the information)
  +        :return The gathered services status list
        """
  ```