### PR TITLE
Display when error occured on update

### DIFF
--- a/web_app/server.py
+++ b/web_app/server.py
@@ -268,6 +268,7 @@ def check_update(source_url = None, current_release = None, prerelease=False, em
              
     except Exception as e:
         print("Check update error: ", e)
+        new_release = { "error" : repr(e)}
         
     if emit:
         socketio.emit("new release", json.dumps(new_release), namespace="/test")

--- a/web_app/static/settings.js
+++ b/web_app/static/settings.js
@@ -376,8 +376,12 @@ $(document).ready(function () {
     socket.on("new release", function(msg) {
         // open modal box asking for starting update
         response = JSON.parse(msg);
-        console.log(response);
-        if (response.new_release) {
+        console.log(JSON.stringify(response));
+        if (response.error) {
+            $("#updateModal .modal-title").text("Update error!");
+            $("#updateModal .modal-body").append(response['error']);
+            $("#updateModal").modal();
+        }else if (response.new_release) {
             $("#updateModal .modal-title").text("Update available!");
             $("#updateModal .modal-body").append('<p class="text-center">Do you want to install <b>' + response['new_release'] +'</b>? <br>It will take a few minutes.</p>');                    
             var newFeaturesArray = response['comment'].split('\r\n');


### PR DESCRIPTION
Replaces pull request #242
Closes issue #221 

Includes displaying error in the dialog on update, and logging the response of any update properly to console by implementing `JSON.stringify`