### PR TITLE
Socket messaging improvements

### DIFF
--- a/web_app/server.py
+++ b/web_app/server.py
@@ -146,6 +146,10 @@ def manager():
     max_cpu_temp = 0
     services_status = getServicesStatus(emit_pingback=False)
     while True:
+        # Make sure max_cpu_temp is always updated
+        cpu_temp = get_cpu_temp()
+        max_cpu_temp = max(cpu_temp, max_cpu_temp)
+
         if connected_clients > 0:
             # We only need to emit to the socket if there are clients able to receive it.
             updated_services_status = getServicesStatus(emit_pingback=False)
@@ -154,8 +158,6 @@ def manager():
                 socketio.emit("services status", json.dumps(services_status), namespace="/test")
                 print("service status", services_status)
 
-            cpu_temp = get_cpu_temp()
-            max_cpu_temp = max(cpu_temp, max_cpu_temp)
             volume_usage = get_volume_usage()
             sys_infos = {"cpu_temp" : cpu_temp,
                         "max_cpu_temp" : max_cpu_temp,


### PR DESCRIPTION
Replaces #231 

Small QOL improvement.

- Only sent system informations when there is a client connected.
- Makes UI more responsive by defaulting `emit_pingback` to `True`, so that the services status get sent back to the client immediate instead of waiting on the manager function:
  ```diff
    @socketio.on("get services status", namespace="/test")
  - def getServicesStatus(emit_pingback=False):
  + def getServicesStatus(emit_pingback=True):
        """
            Get the status of services listed in services_list
            (services_list is global)
          
  +        :param emit_pingback: whether or not the services status is sent to clients 
  +            (defaults to true as the socketio.on() should receive back the information)
  +        :return The gathered services status list
        """
  ```