### PR TITLE
Adding source table information for the local ntrip caster

### DIFF
--- a/run_cast.sh
+++ b/run_cast.sh
@@ -7,7 +7,7 @@
 BASEDIR=$(dirname "$0")
 source <( grep = ${BASEDIR}/settings.conf )  #import settings
 
-
+receiver_info="RTKBase ${receiver},${version}"
 in_serial="serial://${com_port}:${com_port_settings}#${receiver_format}"
 in_tcp="tcpcli://127.0.0.1:${tcp_port}#${receiver_format}"
 #in_ext_tcp is mainly for dev purpose to receive a raw stream from another base
@@ -20,11 +20,15 @@ out_caster_A="ntrips://:${svr_pwd_a}@${svr_addr_a}:${svr_port_a}/${mnt_name_a}#r
 out_caster_B="ntrips://:${svr_pwd_b}@${svr_addr_b}:${svr_port_b}/${mnt_name_b}#rtcm3 -msg ${rtcm_msg_b} -p ${position}"
 #add receiver options if it exists
 [[ ! -z "${ntrip_b_receiver_options}" ]] && out_caster_B=""${out_caster_B}" -opt "${ntrip_b_receiver_options}""
-
-out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
+array_pos=(${position})
+#out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;${version};NONE;N;N;;"
+out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;RTKBase;NONE;N;N;;"
+#out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}""#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
+out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
+#out_local_caster="${out_local_caster}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
 #add receiver options if it exists
-[[ ! -z "${local_ntripc_receiver_options}" ]] && out_local_caster=""${out_local_caster}" -opt "${local_ntripc_receiver_options}""
-
+[[ ! -z "${local_ntripc_receiver_options}" ]] && out_local_caster="${out_local_caster} -opt ${local_ntripc_receiver_options}"
+#exit 0
 out_tcp="tcpsvr://:${tcp_port}"
 
 out_file="file://${datadir}/${file_name}.${receiver_format}::T::S=${file_rotate_time} -f ${file_overlap_time}"
@@ -37,10 +41,8 @@ out_rtcm_serial="serial://${out_com_port}:${out_com_port_settings}#rtcm3 -msg ${
 #add receiver options if it exists
 [[ ! -z "${rtcm_serial_receiver_options}" ]] && out_rtcm_serial=""${out_rtcm_serial}" -opt "${rtcm_serial_receiver_options}""
 
-receiver_info="RTKBase ${receiver},${version}"
-
 mkdir -p ${logdir}
-    
+
   case "$2" in
     out_tcp)
     #echo ${cast} -in ${!1} -out $out_tcp
@@ -50,15 +52,15 @@ mkdir -p ${logdir}
 
   out_caster_A)
     #echo ${cast} -in ${!1} -out $out_caster
-    ${cast} -in ${!1} -out ${out_caster_A} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_A.log &
+    ${cast} -in ${!1} -out "${out_caster_A}" -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_A.log &
     ;;
 
   out_caster_B)
-    ${cast} -in ${!1} -out ${out_caster_B} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_B.log &
+    ${cast} -in ${!1} -out "${out_caster_B}" -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_B.log &
     ;;
 
   out_local_caster)
-    #echo ${cast} -in ${!1} -out $out_local_caster
+    echo ${cast} -in ${!1} -out "${out_local_caster}"
     ${cast} -in ${!1} -out ${out_local_caster} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip.log &
     ;;
 

--- a/run_cast.sh
+++ b/run_cast.sh
@@ -21,16 +21,17 @@ out_caster_B="ntrips://:${svr_pwd_b}@${svr_addr_b}:${svr_port_b}/${mnt_name_b}#r
 #add receiver options if it exists
 [[ ! -z "${ntrip_b_receiver_options}" ]] && out_caster_B=""${out_caster_B}" -opt "${ntrip_b_receiver_options}""
 
-
 array_pos=(${position})
-#out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;${version};NONE;N;N;;"
-out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};${receiver_frequency_count};GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;RTKBase;NONE;N;N;;"
-#out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}""#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
+if [[ ${local_ntripc_user} == '' ]] && [[ ${local_ntripc_pwd} == '' ]]
+  then
+    local_ntripc_auth='N'
+  else
+    local_ntripc_auth='B' #Basic authentification
+fi
+out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};${receiver_frequency_count};GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;RTKBase_${receiver},${version};NONE;${local_ntripc_auth};N;;"
 out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
-#out_local_caster="${out_local_caster}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
 #add receiver options if it exists
 [[ ! -z "${local_ntripc_receiver_options}" ]] && out_local_caster="${out_local_caster} -opt ${local_ntripc_receiver_options}"
-#exit 0
 out_tcp="tcpsvr://:${tcp_port}"
 
 out_file="file://${datadir}/${file_name}.${receiver_format}::T::S=${file_rotate_time} -f ${file_overlap_time}"
@@ -62,7 +63,7 @@ mkdir -p ${logdir}
     ;;
 
   out_local_caster)
-    echo ${cast} -in ${!1} -out "${out_local_caster}"
+    #echo ${cast} -in ${!1} -out "${out_local_caster}"
     ${cast} -in ${!1} -out ${out_local_caster} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip.log &
     ;;
 

--- a/run_cast.sh
+++ b/run_cast.sh
@@ -20,9 +20,11 @@ out_caster_A="ntrips://:${svr_pwd_a}@${svr_addr_a}:${svr_port_a}/${mnt_name_a}#r
 out_caster_B="ntrips://:${svr_pwd_b}@${svr_addr_b}:${svr_port_b}/${mnt_name_b}#rtcm3 -msg ${rtcm_msg_b} -p ${position}"
 #add receiver options if it exists
 [[ ! -z "${ntrip_b_receiver_options}" ]] && out_caster_B=""${out_caster_B}" -opt "${ntrip_b_receiver_options}""
+
+
 array_pos=(${position})
 #out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;${version};NONE;N;N;;"
-out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;RTKBase;NONE;N;N;;"
+out_local_caster_source_table="${local_ntripc_mnt_name};rtcm3;${local_ntripc_msg};${receiver_frequency_count};GPS+GLO+GAL+BDS+QZS;NONE;NONE;${array_pos[0]};${array_pos[1]};0;0;RTKBase;NONE;N;N;;"
 #out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}""#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
 out_local_caster="ntripc://${local_ntripc_user}:${local_ntripc_pwd}@:${local_ntripc_port}/${local_ntripc_mnt_name}:${out_local_caster_source_table}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"
 #out_local_caster="${out_local_caster}#rtcm3 -msg ${local_ntripc_msg} -p ${position}"

--- a/settings.conf.default
+++ b/settings.conf.default
@@ -33,7 +33,7 @@ receiver='unknown'
 #gnss receiver format
 receiver_format=''
 #gnss receiver frequency available
-receiver_frequency=''
+receiver_frequency_count=''
 #Antenna info, id, serial number. Without space inside the strings
 antenna_info='ADVNULLANTENNA'
 #tcp port for RAW stream. If you change this value, edit gpsd conf file to reflect the port in DEVICES.

--- a/settings.conf.default
+++ b/settings.conf.default
@@ -32,6 +32,8 @@ com_port_settings='115200:8:n:1'
 receiver='unknown'
 #gnss receiver format
 receiver_format=''
+#gnss receiver frequency available
+receiver_frequency=''
 #Antenna info, id, serial number. Without space inside the strings
 antenna_info='ADVNULLANTENNA'
 #tcp port for RAW stream. If you change this value, edit gpsd conf file to reflect the port in DEVICES.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -392,7 +392,7 @@ configure_gnss(){
           sudo -u "${RTKBASE_USER}" sed -i s/^com_port_settings=.*/com_port_settings=\'115200:8:n:1\'/ "${rtkbase_path}"/settings.conf  && \
           sudo -u "${RTKBASE_USER}" sed -i s/^receiver=.*/receiver=\'U-blox_ZED-F9P\'/ "${rtkbase_path}"/settings.conf                  && \
           sudo -u "${RTKBASE_USER}" sed -i s/^receiver_format=.*/receiver_format=\'ubx\'/ "${rtkbase_path}"/settings.conf               && \
-          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_frequency=.*/receiver_frequency=\'L1-L2\'/ "${rtkbase_path}"/settings.conf       && \
+          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_frequency=.*/receiver_frequency=\'L1-L2\'/ "${rtkbase_path}"/settings.conf
           return $?
         else
           echo 'No Gnss receiver has been set. We can'\''t configure'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -355,7 +355,7 @@ detect_usb_gnss() {
           else
             #create settings.conf with the com_port setting and the settings needed to start str2str_tcp
             #as it could start before the web server merge settings.conf.default and settings.conf
-            sudo -u "${RTKBASE_USER}" printf "[main]\ncom_port='"${detected_gnss[0]}"'\ncom_port_settings='115200:8:n:1'\nreceiver_format=''\ntcp_port='5015'\n" > "${rtkbase_path}"/settings.conf
+            sudo -u "${RTKBASE_USER}" printf "[main]\ncom_port='"${detected_gnss[0]}"'\ncom_port_settings='115200:8:n:1'\nreceiver=''\nreceiver_format=''\nreceiver_frequency=''\ntcp_port='5015'\n" > "${rtkbase_path}"/settings.conf
             #add option -TADJ=1 on rtcm/ntrip_a/ntrip_b/serial outputs
             sudo -u "${RTKBASE_USER}" printf "[ntrip_a]\nntrip_a_receiver_options='-TADJ=1'\n[ntrip_b]\nntrip_b_receiver_options='-TADJ=1'\n[local_ntrip]\nlocal_ntripc_receiver_options='-TADJ=1'\n[rtcm_svr]\nrtcm_receiver_options='-TADJ=1'\n[rtcm_serial]\nrtcm_serial_receiver_options='-TADJ=1'\n" >> "${rtkbase_path}"/settings.conf
 
@@ -391,7 +391,8 @@ configure_gnss(){
           #now that the receiver is configured, we can set the right values inside settings.conf
           sudo -u "${RTKBASE_USER}" sed -i s/^com_port_settings=.*/com_port_settings=\'115200:8:n:1\'/ "${rtkbase_path}"/settings.conf  && \
           sudo -u "${RTKBASE_USER}" sed -i s/^receiver=.*/receiver=\'U-blox_ZED-F9P\'/ "${rtkbase_path}"/settings.conf                  && \
-          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_format=.*/receiver_format=\'ubx\'/ "${rtkbase_path}"/settings.conf
+          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_format=.*/receiver_format=\'ubx\'/ "${rtkbase_path}"/settings.conf               && \
+          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_frequency=.*/receiver_frequency=\'L1-L2\'/ "${rtkbase_path}"/settings.conf       && \
           return $?
         else
           echo 'No Gnss receiver has been set. We can'\''t configure'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -355,7 +355,7 @@ detect_usb_gnss() {
           else
             #create settings.conf with the com_port setting and the settings needed to start str2str_tcp
             #as it could start before the web server merge settings.conf.default and settings.conf
-            sudo -u "${RTKBASE_USER}" printf "[main]\ncom_port='"${detected_gnss[0]}"'\ncom_port_settings='115200:8:n:1'\nreceiver=''\nreceiver_format=''\nreceiver_frequency=''\ntcp_port='5015'\n" > "${rtkbase_path}"/settings.conf
+            sudo -u "${RTKBASE_USER}" printf "[main]\ncom_port='"${detected_gnss[0]}"'\ncom_port_settings='115200:8:n:1'\nreceiver=''\nreceiver_format=''\nreceiver_frequency_count=''\ntcp_port='5015'\n" > "${rtkbase_path}"/settings.conf
             #add option -TADJ=1 on rtcm/ntrip_a/ntrip_b/serial outputs
             sudo -u "${RTKBASE_USER}" printf "[ntrip_a]\nntrip_a_receiver_options='-TADJ=1'\n[ntrip_b]\nntrip_b_receiver_options='-TADJ=1'\n[local_ntrip]\nlocal_ntripc_receiver_options='-TADJ=1'\n[rtcm_svr]\nrtcm_receiver_options='-TADJ=1'\n[rtcm_serial]\nrtcm_serial_receiver_options='-TADJ=1'\n" >> "${rtkbase_path}"/settings.conf
 
@@ -392,7 +392,7 @@ configure_gnss(){
           sudo -u "${RTKBASE_USER}" sed -i s/^com_port_settings=.*/com_port_settings=\'115200:8:n:1\'/ "${rtkbase_path}"/settings.conf  && \
           sudo -u "${RTKBASE_USER}" sed -i s/^receiver=.*/receiver=\'U-blox_ZED-F9P\'/ "${rtkbase_path}"/settings.conf                  && \
           sudo -u "${RTKBASE_USER}" sed -i s/^receiver_format=.*/receiver_format=\'ubx\'/ "${rtkbase_path}"/settings.conf               && \
-          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_frequency=.*/receiver_frequency=\'L1-L2\'/ "${rtkbase_path}"/settings.conf
+          sudo -u "${RTKBASE_USER}" sed -i s/^receiver_frequency_count=.*/receiver_frequency_count=\'2\'/ "${rtkbase_path}"/settings.conf
           return $?
         else
           echo 'No Gnss receiver has been set. We can'\''t configure'


### PR DESCRIPTION
Should fix #183 

example:
```
SOURCETABLE 200 OK
Server: RTKLIB 2.4.3 b34
Date: 2022/11/08 21:09:47 UTC
Connection: close
Content-Type: text/plain
Content-Length: 230

STR;DEV;DEV;rtcm3;1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230;2;GPS+GLO+GAL+BDS+QZS;NONE;NONE;47.0983869;-1.2655108;0;0;RTKBase_U-blox_ZED-F9P,2.3.5;NONE;B;N;;
ENDSOURCETABLE
```

There is one thing I didn't succeeded : Having white space in the generator column. Each time I try this, the argument sent to str2str are not split as it should. 