### PR TITLE
Add help message when no arguments provided in install.sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -473,13 +473,14 @@ main() {
 
   PARSED_ARGUMENTS=$(getopt --name install --options hu:drbi:tgencsv:a --longoptions help,user:,dependencies,rtklib,rtkbase-release,rtkbase-repo:,unit-files,gpsd-chrony,detect-usb-gnss,no-write-port,configure-gnss,start-services,alldev:,all -- "$@")
   VALID_ARGUMENTS=$?
-  if [ "$VALID_ARGUMENTS" != "0" ]; then
-    #man_help
-    echo 'Try '\''install.sh --help'\'' for more information'
+
+  # If the parsing failed OR no arguments where passed, then display help
+  if [[ "$VALID_ARGUMENTS" != "0" ]] || [[ "$PARSED_ARGUMENTS" == " --" ]]; then
+    echo 'Invalid usage, try '\''install.sh --help'\'' for more information'
     exit 1
   fi
 
-  echo "PARSED_ARGUMENTS is $PARSED_ARGUMENTS"
+  echo "PARSED_ARGUMENTS is '$PARSED_ARGUMENTS'"
   eval set -- "$PARSED_ARGUMENTS"
   while :
     do


### PR DESCRIPTION
The install.sh script didn't show anything useful when running the bare minimum command without arguments. With this PR it displays as followed:

Before
![image](https://user-images.githubusercontent.com/29043784/201118482-d4d8d922-28d4-434e-84a3-195c1205c101.png)

After
![image](https://user-images.githubusercontent.com/29043784/201118533-9343e747-4bdb-4cac-947e-448b2ec7bc28.png)
