### PR TITLE
Option for ./install.sh --all argument

### DIFF
--- a/settings.conf.default
+++ b/settings.conf.default
@@ -2,7 +2,7 @@
 
 [general]
 # Version
-version=2.4
+version=2.4b5
 # Rtkbase upgrade mandatory "checkpoint"
 checkpoint_version=2.5.0
 # User who runs str2str_file service

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -3,6 +3,17 @@
 
 BASEDIR=$(dirname "$0")
 cd ${BASEDIR}/../..
+
+BUNDLED=${1}
+if [[ ${BUNDLED} == '--bundled' ]]
+then
+    ARCHIVE_NAME='rtkbase.tar.xz'
+    TAR_ARG='-cJf'
+else
+    ARCHIVE_NAME='rtkbase.tar.gz'
+    TAR_ARG='-zcvf'
+fi
+
 tar --exclude-vcs \
     --exclude='rtkbase/data' \
     --exclude='rtkbase/drawing' \
@@ -15,7 +26,17 @@ tar --exclude-vcs \
     --exclude='test.sh' \
     --exclude='test.conf' \
     --exclude='*.pyc' \
-    -zcvf rtkbase.tar.gz rtkbase/
+    $TAR_ARG $ARCHIVE_NAME rtkbase/
+ 
 echo '========================================================'
-echo 'Archive rtkbase.tar.gz created inside' $(pwd)
+echo 'Archive ' $ARCHIVE_NAME ' created inside' $(pwd)
 echo '========================================================'
+
+if [[ ${BUNDLED} == '--bundled' ]]
+then
+    cat rtkbase/tools/install.sh $ARCHIVE_NAME > install.sh
+    chmod +x install.sh
+    echo 'Bundled script install.sh created inside' $(pwd)
+    echo '========================================================'
+
+fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -554,8 +554,8 @@ main() {
   then
     # test if rtkbase source option is correct
     [[ ' release repo url bundled'  =~ (^|[[:space:]])$ARG_ALL($|[[:space:]]) ]] || { echo 'wrong option, please choose release, repo, url or bundled' ; exit 1 ;}
-    [[ $ARG_ALL == 'repo' ]] && [[ "${ARG_RTKBASE_REPO}" == "" ]] && { echo 'you have to specify the branch with --rtkbase-repo' ; exit 1 ;}
-    [[ $ARG_ALL == 'url' ]] && [[ "${ARG_RTKBASE_SRC}" == "" ]] && { echo 'you have to specify the url with --rtkbase-custom' ; exit 1 ;}
+    [[ $ARG_ALL == 'repo' ]] && [[ "${ARG_RTKBASE_REPO}" == "0" ]] && { echo 'you have to specify the branch with --rtkbase-repo' ; exit 1 ;}
+    [[ $ARG_ALL == 'url' ]] && [[ "${ARG_RTKBASE_SRC}" == "0" ]] && { echo 'you have to specify the url with --rtkbase-custom' ; exit 1 ;}
     # What is this || true ? It's because if ((..)) result is 0, exit code is 1. See https://www.shellcheck.net/wiki/SC2219
     install_dependencies && \
     install_rtklib   && \

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -556,7 +556,7 @@ main() {
     [[ ' release repo url bundled'  =~ (^|[[:space:]])$ARG_ALL($|[[:space:]]) ]] || { echo 'wrong option, please choose release, repo, url or bundled' ; exit 1 ;}
     [[ $ARG_ALL == 'repo' ]] && [[ "${ARG_RTKBASE_REPO}" == "0" ]] && { echo 'you have to specify the branch with --rtkbase-repo' ; exit 1 ;}
     [[ $ARG_ALL == 'url' ]] && [[ "${ARG_RTKBASE_SRC}" == "0" ]] && { echo 'you have to specify the url with --rtkbase-custom' ; exit 1 ;}
-    # What is this || true ? It's because if ((..)) result is 0, exit code is 1. See https://www.shellcheck.net/wiki/SC2219
+    #Okay launching installation
     install_dependencies && \
     install_rtklib   && \
     case $ARG_ALL in

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -29,6 +29,9 @@ rm /usr/bin/str2str
 rm /usr/bin/conv2bin
 rm /usr/bin/rtkrcv
 
+#removing Python modules
+# Too dangerous without running RTKBase in a venv ?
+
 #removing rtkbase folder
 echo 'Deleting rtkbase directory'
 rtkbase_dir=$(builtin cd "${BASEDIR}"/.. ; pwd)

--- a/web_app/requirements.txt
+++ b/web_app/requirements.txt
@@ -1,10 +1,10 @@
-cryptography==37.0.4
+cryptography==39.0.0
 itsdangerous==2.1.2
 Flask==2.2.2
-Flask-SocketIO==5.3.0
-eventlet==0.33.1
-Bootstrap-Flask==2.1.0
-Flask-WTF==1.0.1
+Flask-SocketIO==5.3.2
+eventlet==0.33.3
+Bootstrap-Flask==2.2.0
+Flask-WTF==1.1.1
 Flask-Login==0.6.2
 #On some linux distribution, pexpect and psutil are already installed
 #and can't be upgraded with pip. In these cases, pip fail, leaving
@@ -12,8 +12,9 @@ Flask-Login==0.6.2
 #With pexpect <=4.8.0, pip will not fail.
 #With psutil <= 5.8.0, pip will not fail.
 pexpect<=4.8.0
-psutil<=5.9.0
-pyOpenSSL==22.0.0
+psutil<=5.9.4
+pyOpenSSL==23.0.0
 pyserial==3.5
 pystemd==0.10.0
 requests==2.28.1
+dnspython==2.3.0


### PR DESCRIPTION
Prior to this pull request, installing Rtkbase with anything other than the official release needed to write all the install.sh options

With this PR you can use:
`sudo ./install.sh --all release` to get the release
`sudo ./install.sh --all repo --rtkbase-repo dev` to install from the dev branch
`sudo ./install.sh --all url --rtkbase-custom url_to_rtkbase_archive` to install rtkbase from a custom url
`sudo ./install.sh --all bundled` to install rtkbase from a bundled rtkbase created with `rtkbase/tools/create_release.sh --bundled`
