### PR TITLE
Check os release before upgrade

### DIFF
--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -21,6 +21,8 @@ check_before_update() {
   if [[ -f /etc/os-release ]]
     then
       source /etc/os-release
+    else
+      printf "Warning! We can't check your Os release, upgrade at your own risk\n"      
   fi
 
   case $ID in

--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -13,6 +13,13 @@ destination_directory=$2
 data_dir=$3
 old_version=$4
 standard_user=$5
+checking=$6
+
+check_update() {
+  echo 'error (test)' >&2
+  echo 'error line 2' >&2
+  exit 1
+}
 
 update() {
 echo "remove existing rtkbase.old directory"
@@ -26,8 +33,13 @@ cp -r ${destination_directory}/!(${data_dir}) /var/tmp/rtkbase.old
 #systemctl stop rtkbase_web.service
 
 echo "copy new release to destination"
-cp -rfp ${source_directory}/. ${destination_directory}
-
+if [[ -d ${source_directory} ]] && [[ -d ${destination_directory} ]] 
+  then
+    cp -rfp ${source_directory}/. ${destination_directory}
+  else
+    echo 'can t copy'
+    exit 1
+fi
 }
 
 insert_rtcm_msg() {
@@ -269,7 +281,11 @@ upd_2.4.2() {
   [ $str2str_file = 'active' ] && systemctl start str2str_file
 }
 
+#check if we can apply the update
+[[ $checking == '--checking' ]] && check_update
 # standard update
+echo "exit test"
+exit 0
 update
 # calling specific update function. If we are using v2.2.5, it will call the function upd_2.2.5
 upd_"${old_version/b*/b}" "$@"

--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -311,6 +311,7 @@ upd_2.4.2() {
 }
 
 #check if we can apply the update
+#FOR THE OLDER ME -> Don't forget to modify the os detection if there is a 2.5.x release !!!
 [[ $checking == '--checking' ]] && check_before_update
 
 # standard update

--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -27,21 +27,21 @@ check_before_update() {
     debian)
       if (( $(echo "$VERSION_ID < 10" | bc -l) ))
       then
-        printf "${TOO_OLD}"
+        printf "${TOO_OLD}" >/dev/stderr
         exit 1
       fi
       ;;
     raspbian)
     if (( $(echo "$VERSION_ID < 10" | bc -l) ))
       then
-        echo "${TOO_OLD}"
+        printf "${TOO_OLD}" >/dev/stderr
         exit 1
       fi
       ;;
     ubuntu)
       if (( $(echo "$VERSION_ID < 20.04" | bc -l) ))
       then
-        printf "${TOO_OLD}"
+        printf "${TOO_OLD}" >/dev/stderr
         exit 1
       fi
       ;;
@@ -310,9 +310,8 @@ upd_2.4.2() {
 
 #check if we can apply the update
 [[ $checking == '--checking' ]] && check_before_update
+
 # standard update
-echo "exit test"
-exit 0
 update
 # calling specific update function. If we are using v2.2.5, it will call the function upd_2.2.5
 upd_"${old_version/b*/b}" "$@"

--- a/rtkbase_update.sh
+++ b/rtkbase_update.sh
@@ -15,14 +15,41 @@ old_version=$4
 standard_user=$5
 checking=$6
 
-check_update() {
-  echo 'error (test)' >&2
-  echo 'error line 2' >&2
-  exit 1
+check_before_update() {
+  TOO_OLD='You'"'"'re Operating System is too old\nPlease update it or reflash you SDCard with a more recent RTKBase image\n'
+
+  if [[ -f /etc/os-release ]]
+    then
+      source /etc/os-release
+  fi
+
+  case $ID in
+    debian)
+      if (( $(echo "$VERSION_ID < 10" | bc -l) ))
+      then
+        printf "${TOO_OLD}"
+        exit 1
+      fi
+      ;;
+    raspbian)
+    if (( $(echo "$VERSION_ID < 10" | bc -l) ))
+      then
+        echo "${TOO_OLD}"
+        exit 1
+      fi
+      ;;
+    ubuntu)
+      if (( $(echo "$VERSION_ID < 20.04" | bc -l) ))
+      then
+        printf "${TOO_OLD}"
+        exit 1
+      fi
+      ;;
+  esac
 }
 
 update() {
-echo "remove existing rtkbase.old directory"
+echo 'remove existing rtkbase.old directory'
 rm -rf /var/tmp/rtkbase.old
 mkdir /var/tmp/rtkbase.old
 
@@ -282,7 +309,7 @@ upd_2.4.2() {
 }
 
 #check if we can apply the update
-[[ $checking == '--checking' ]] && check_update
+[[ $checking == '--checking' ]] && check_before_update
 # standard update
 echo "exit test"
 exit 0

--- a/web_app/server.py
+++ b/web_app/server.py
@@ -261,10 +261,10 @@ def check_update(source_url = None, current_release = None, prerelease=rtkbaseco
         :return The new release version inside a dict (release version and url for this release)
     """
     ## test
-    new_release = {'url' : 'http://localhost', 'new_release' : "3.9", "comment" : "blabla"}
-    if emit:
-        socketio.emit("new release", json.dumps(new_release), namespace="/test")
-    return new_release
+    #new_release = {'url' : 'http://localhost', 'new_release' : "3.9", "comment" : "blabla"}
+    #if emit:
+    #    socketio.emit("new release", json.dumps(new_release), namespace="/test")
+    #return new_release
     ## test
 
     new_release = {}
@@ -311,16 +311,13 @@ def update_rtkbase(update_file=False):
         if update_url is None:
             return
         #Download update
-        #update_archive = download_update(update_url)
+        update_archive = download_update(update_url)
     else:
         #update from file
         update_file.save("/var/tmp/rtkbase_update.tar.gz")
         update_archive = "/var/tmp/rtkbase_update.tar.gz"
         print("update stored in /var/tmp/")
     
-    ### test
-    update_archive='prout'
-    ### test
     if update_archive is None:
         socketio.emit("downloading_update", json.dumps({"result": 'false'}), namespace="/test")
         return
@@ -328,24 +325,21 @@ def update_rtkbase(update_file=False):
         socketio.emit("downloading_update", json.dumps({"result": 'true'}), namespace="/test")
 
     #Get the "root" folder in the archive
-    #tar = tarfile.open(update_archive)
-    #for tarinfo in tar:
-    #    if tarinfo.isdir():
-    #        primary_folder = tarinfo.name
-    #        break
+    tar = tarfile.open(update_archive)
+    for tarinfo in tar:
+        if tarinfo.isdir():
+            primary_folder = tarinfo.name
+            break
     #Delete previous update directory
-    #try:
-    #    os.rmdir("/var/tmp/rtkbase")
-    #except FileNotFoundError:
-    #    print("/var/tmp/rtkbase directory doesn't exist")
+    try:
+        os.rmdir("/var/tmp/rtkbase")
+    except FileNotFoundError:
+        print("/var/tmp/rtkbase directory doesn't exist")
         
     #Extract archive
-    #tar.extractall("/var/tmp")
+    tar.extractall("/var/tmp")
 
-    #source_path = os.path.join("/var/tmp/", primary_folder)
-    ##test
-    source_path = os.path.join("/var/tmp/", 'rtkbase_test')
-    ##test
+    source_path = os.path.join("/var/tmp/", primary_folder)
     script_path = os.path.join(source_path, "rtkbase_update.sh")
     current_release = rtkbaseconfig.get("general", "version").strip("v")
     standard_user = rtkbaseconfig.get("general", "user")

--- a/web_app/server.py
+++ b/web_app/server.py
@@ -260,6 +260,13 @@ def check_update(source_url = None, current_release = None, prerelease=rtkbaseco
         :param emit: send the result to the web front end with socketio
         :return The new release version inside a dict (release version and url for this release)
     """
+    ## test
+    new_release = {'url' : 'http://localhost', 'new_release' : "3.9", "comment" : "blabla"}
+    if emit:
+        socketio.emit("new release", json.dumps(new_release), namespace="/test")
+    return new_release
+    ## test
+
     new_release = {}
     source_url = source_url if source_url is not None else "https://api.github.com/repos/stefal/rtkbase/releases"
     current_release = current_release if current_release is not None else rtkbaseconfig.get("general", "version").strip("v")
@@ -291,7 +298,7 @@ def check_update(source_url = None, current_release = None, prerelease=rtkbaseco
 @socketio.on("update rtkbase", namespace="/test")
 def update_rtkbase(update_file=False):
     """
-        Check if a RTKBase exists, download it and update rtkbase
+        Check if a RTKBase update exists, download it and update rtkbase
         if update_file is a link to a file, use it to update rtkbase (mainly used for dev purpose)
     """
 
@@ -304,13 +311,16 @@ def update_rtkbase(update_file=False):
         if update_url is None:
             return
         #Download update
-        update_archive = download_update(update_url)
+        #update_archive = download_update(update_url)
     else:
         #update from file
         update_file.save("/var/tmp/rtkbase_update.tar.gz")
         update_archive = "/var/tmp/rtkbase_update.tar.gz"
         print("update stored in /var/tmp/")
-        
+    
+    ### test
+    update_archive='prout'
+    ### test
     if update_archive is None:
         socketio.emit("downloading_update", json.dumps({"result": 'false'}), namespace="/test")
         return
@@ -318,29 +328,36 @@ def update_rtkbase(update_file=False):
         socketio.emit("downloading_update", json.dumps({"result": 'true'}), namespace="/test")
 
     #Get the "root" folder in the archive
-    tar = tarfile.open(update_archive)
-    for tarinfo in tar:
-        if tarinfo.isdir():
-            primary_folder = tarinfo.name
-            break
+    #tar = tarfile.open(update_archive)
+    #for tarinfo in tar:
+    #    if tarinfo.isdir():
+    #        primary_folder = tarinfo.name
+    #        break
     #Delete previous update directory
-    try:
-        os.rmdir("/var/tmp/rtkbase")
-    except FileNotFoundError:
-        print("/var/tmp/rtkbase directory doesn't exist")
+    #try:
+    #    os.rmdir("/var/tmp/rtkbase")
+    #except FileNotFoundError:
+    #    print("/var/tmp/rtkbase directory doesn't exist")
         
     #Extract archive
-    tar.extractall("/var/tmp")
+    #tar.extractall("/var/tmp")
 
-    #launch update script
-    rtk.shutdownBase()
-    source_path = os.path.join("/var/tmp/", primary_folder)
+    #source_path = os.path.join("/var/tmp/", primary_folder)
+    ##test
+    source_path = os.path.join("/var/tmp/", 'rtkbase_test')
+    ##test
     script_path = os.path.join(source_path, "rtkbase_update.sh")
     current_release = rtkbaseconfig.get("general", "version").strip("v")
     standard_user = rtkbaseconfig.get("general", "user")
-    socketio.emit("updating_rtkbase", namespace="/test")
-    time.sleep(1)
-    os.execl(script_path, "unused arg0", source_path, rtkbase_path, app.config["DOWNLOAD_FOLDER"].split("/")[-1], current_release, standard_user)
+    #launch update verifications
+    answer = subprocess.run([script_path, source_path, rtkbase_path, app.config["DOWNLOAD_FOLDER"].split("/")[-1], current_release, standard_user, "--checking"], encoding="UTF-8", stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    if answer.returncode != 0:
+        socketio.emit("updating_rtkbase_stopped", json.dumps({"error" : answer.stderr.splitlines()}), namespace="/test")
+    else : #if ok, launch update script
+        socketio.emit("updating_rtkbase", namespace="/test")
+        rtk.shutdownBase()
+        time.sleep(1)
+        os.execl(script_path, "unused arg0", source_path, rtkbase_path, app.config["DOWNLOAD_FOLDER"].split("/")[-1], current_release, standard_user)
 
 def download_update(update_path):
     update_archive = "/var/tmp/rtkbase_update.tar.gz"

--- a/web_app/static/settings.js
+++ b/web_app/static/settings.js
@@ -466,6 +466,19 @@ $(document).ready(function () {
         }
     })
 
+    socket.on("updating_rtkbase_stopped", function(msg) {
+        response = JSON.parse(msg);
+        console.log("mgs: " + response.error)
+        $("#updateModal .modal-title").text("Error !");
+        $("#updateModal .modal-body").text("");
+        for (line of response.error) {
+            $("#updateModal .modal-body").append("<p>" + line + "</p>");
+        }
+        $("#start-update-button").html('Update');
+        $("#start-update-button").prop("disabled", true);
+        $("#cancel-button").prop("disabled", false);
+    })
+
     socket.on("updating_rtkbase", function() {
         $("#updateModal .modal-body").text("Please wait...Updating...");
         update_countdown(600, 0);


### PR DESCRIPTION
Adding a way to check if the operating system is too old before upgrading.
The goal is to stop the upgrade if the Os release is older than current debian release -2.

Current debian release is 12 (Bookworm) -> block upgrade is the Os is debian 9 or older (Stretch).

Because it needs some code directly inside RTKBase web app, We can't stop upgrading from 2.4 to 2.5
It will block upgrade from 2.5 to 2.5.x <- ⚠️ Warning !!
It will block upgrade from 2.5 to 2.6