### PR TITLE
change service type from forking to simple

### DIFF
--- a/run_cast.sh
+++ b/run_cast.sh
@@ -59,41 +59,41 @@ mkdir -p ${logdir}
     out_tcp)
     #echo ${cast} -in ${!1} -out $out_tcp
     # What is this ${!1} ? It's variable indirection
-    ${cast} -in ${!1} -out ${out_tcp} -b 1 -t ${level} -fl ${logdir}/str2str_tcp.log &
+    ${cast} -in ${!1} -out ${out_tcp} -b 1 -t ${level} -fl ${logdir}/str2str_tcp_$(date "+%F-%T").log
     ;;
 
   out_caster_A)
     #echo ${cast} -in ${!1} -out $out_caster
-    ${cast} -in ${!1} ${out_caster_A} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_A.log &
+    ${cast} -in ${!1} ${out_caster_A} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_A.log
     ;;
 
   out_caster_B)
-    ${cast} -in ${!1} ${out_caster_B} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_B.log &
+    ${cast} -in ${!1} ${out_caster_B} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip_B.log
     ;;
 
   out_local_caster)
     #echo ${cast} -in ${!1} -out "${out_local_caster}"
-    ${cast} -in ${!1} ${out_local_caster} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip.log &
+    ${cast} -in ${!1} ${out_local_caster} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_ntrip.log
     ;;
 
   out_rtcm_svr)
     #echo ${cast} -in ${!1} -out $out_rtcm_svr
-    ${cast} -in ${!1} ${out_rtcm_svr} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_svr.log &
+    ${cast} -in ${!1} ${out_rtcm_svr} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_svr.log
     ;;
   
   out_rtcm_client)
     #echo ${cast} -in ${!1} -out $out_rtcm_client
-    ${cast} -in ${!1} ${out_rtcm_client} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_client.log &
+    ${cast} -in ${!1} ${out_rtcm_client} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_client.log
   ;;
 
   out_rtcm_udp_svr)
     #echo ${cast} -in ${!1} -out $out_rtcm_udp_svr
-    ${cast} -in ${!1} ${out_rtcm_udp_svr} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_udp_svr.log &
+    ${cast} -in ${!1} ${out_rtcm_udp_svr} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_udp_svr.log
     ;;
   
   out_rtcm_serial)
     #echo ${cast} -in ${!1} -out $out_rtcm_serial
-    ${cast} -in ${!1} ${out_rtcm_serial} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_serial.log &
+    ${cast} -in ${!1} ${out_rtcm_serial} -i "${receiver_info}" -a "${antenna_info}" -t ${level} -fl ${logdir}/str2str_rtcm_serial.log
     ;;
 
   out_file)
@@ -103,7 +103,7 @@ mkdir -p ${logdir}
     if [ ${ret} -eq 0 ]
     then
       mkdir -p ${datadir}
-      ${cast} -in ${!1} -out ${out_file} -t ${level} -fl ${logdir}/str2str_file.log &
+      ${cast} -in ${!1} -out ${out_file} -t ${level} -fl ${logdir}/str2str_file.log
     fi
     ;;
     

--- a/unit/str2str_file.service
+++ b/unit/str2str_file.service
@@ -4,7 +4,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_file
 Restart=on-failure

--- a/unit/str2str_local_ntrip_caster.service
+++ b/unit/str2str_local_ntrip_caster.service
@@ -6,7 +6,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_local_caster
 Restart=on-failure

--- a/unit/str2str_ntrip_A.service
+++ b/unit/str2str_ntrip_A.service
@@ -6,7 +6,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_caster_A
 Restart=on-failure

--- a/unit/str2str_ntrip_B.service
+++ b/unit/str2str_ntrip_B.service
@@ -6,7 +6,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_caster_B
 Restart=on-failure

--- a/unit/str2str_rtcm_serial.service
+++ b/unit/str2str_rtcm_serial.service
@@ -6,7 +6,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_rtcm_serial
 Restart=on-failure

--- a/unit/str2str_rtcm_svr.service
+++ b/unit/str2str_rtcm_svr.service
@@ -6,7 +6,7 @@ Requires=str2str_tcp.service
 After=str2str_tcp.service
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_tcp out_rtcm_svr
 Restart=on-failure

--- a/unit/str2str_tcp.service
+++ b/unit/str2str_tcp.service
@@ -5,7 +5,7 @@ Description=RTKBase Tcp
 #Requires=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 User={user}
 ExecStart={script_path}/run_cast.sh in_serial out_tcp
 Restart=on-failure


### PR DESCRIPTION
If the receiver serial port isn't available when the service str2str_tcp starts, it could failed, stop, and never restart.
With this update, the service stop with a failure exit, and then it will try to restart.

it should fix #463 and maybe #483

